### PR TITLE
se agregan preprocesadores de mapstruct y lombok

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,13 +41,6 @@
 			<artifactId>spring-boot-starter-security</artifactId>
 		</dependency>
 
-		<!-- MapStruct -->
-		<dependency>
-        <groupId>org.mapstruct</groupId>
-        <artifactId>mapstruct</artifactId>
-        <version>${org.mapstruct.version}</version>
-    </dependency>
-
 		<!--jwt -->
 		<dependency>
 			<groupId>io.jsonwebtoken</groupId>
@@ -92,11 +85,6 @@
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.projectlombok</groupId>
-			<artifactId>lombok</artifactId>
-			<optional>true</optional>
-		</dependency>
-		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
@@ -106,41 +94,50 @@
 			<artifactId>spring-security-test</artifactId>
 			<scope>test</scope>
 		</dependency>
-	</dependencies>
+    <!-- Lombok -->
+    <dependency>
+        <groupId>org.projectlombok</groupId>
+        <artifactId>lombok</artifactId>
+        <version>1.18.30</version>
+        <optional>true</optional>
+    </dependency>
+    
+    <!-- MapStruct -->
+    <dependency>
+        <groupId>org.mapstruct</groupId>
+        <artifactId>mapstruct</artifactId>
+        <version>${org.mapstruct.version}</version>
+    </dependency>
+</dependencies>
 
 <build>
-  <plugins>
-    <!-- Plugin para compilar con MapStruct y Lombok -->
-    <plugin>
-      <groupId>org.apache.maven.plugins</groupId>
-      <artifactId>maven-compiler-plugin</artifactId>
-      <configuration>
-        <source>17</source>
-        <target>17</target>
-        <annotationProcessorPaths>
-          <!-- MapStruct processor -->
-          <path>
-            <groupId>org.mapstruct</groupId>
-            <artifactId>mapstruct-processor</artifactId>
-            <version>${org.mapstruct.version}</version>
-          </path>
-          <!-- Lombok processor -->
-          <path>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <version>1.18.30</version>
-          </path>
-        </annotationProcessorPaths>
-      </configuration>
-    </plugin>
-
-    <!-- Spring Boot plugin -->
-    <plugin>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-maven-plugin</artifactId>
-    </plugin>
-  </plugins>
+    <plugins>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <version>3.8.1</version>
+            <configuration>
+                <source>17</source>
+                <target>17</target>
+                <annotationProcessorPaths>
+                    <path>
+                        <groupId>org.projectlombok</groupId>
+                        <artifactId>lombok</artifactId>
+                        <version>1.18.30</version>
+                    </path>
+                    <path>
+                        <groupId>org.mapstruct</groupId>
+                        <artifactId>mapstruct-processor</artifactId>
+                        <version>1.5.5.Final</version>
+                    </path>
+                    <path>
+                        <groupId>org.projectlombok</groupId>
+                        <artifactId>lombok-mapstruct-binding</artifactId>
+                        <version>0.2.0</version>
+                    </path>
+                </annotationProcessorPaths>
+            </configuration>
+        </plugin>
+    </plugins>
 </build>
-
-
 </project>


### PR DESCRIPTION
Se agregó la configuración del plugin maven-compiler-plugin con Java 17 y los annotationProcessorPaths necesarios para que herramientas como IntelliJ IDEA y la consola de Maven puedan procesar correctamente las anotaciones de MapStruct y Lombok de forma conjunta.

Incluye:
lombok-mapstruct-binding: Permite que Lombok y MapStruct trabajen juntos sin conflictos.

Con esta configuración, los mapeos generados por MapStruct y los métodos generados por Lombok (como getters/setters y constructores) son correctamente reconocidos durante la compilación y por el IDE, evitando errores como "no se encuentra método getX()" al compilar o al navegar el código.